### PR TITLE
Using whitespace tokenizer in tag

### DIFF
--- a/src/posts/frontmatter/matter.rs
+++ b/src/posts/frontmatter/matter.rs
@@ -15,7 +15,7 @@ pub struct FrontMatter {
     description: String,
     lang: Lang,
     category: String,
-    tags: Option<Vec<String>>,
+    pub tags: Option<Vec<String>>,
     created_at: Option<DateTimeWithFormat>,
     updated_at: Option<DateTimeWithFormat>,
 }

--- a/src/posts/posts.rs
+++ b/src/posts/posts.rs
@@ -103,6 +103,11 @@ impl Post {
     }
 
     #[allow(dead_code)]
+    pub fn tags_mut(&mut self) -> &mut Option<Vec<String>> {
+        &mut self.matter.tags
+    }
+
+    #[allow(dead_code)]
     pub fn description(&self) -> String {
         self.matter.description()
     }

--- a/src/text_engine/index.rs
+++ b/src/text_engine/index.rs
@@ -10,6 +10,7 @@ use tantivy::Index;
 use tantivy::tokenizer::LowerCaser;
 use tantivy::tokenizer::RawTokenizer;
 use tantivy::tokenizer::TextAnalyzer;
+use tantivy::tokenizer::WhitespaceTokenizer;
 use tantivy::Result;
 
 use crate::posts::Lang;
@@ -42,6 +43,9 @@ pub fn read_or_build_index(schema: Schema, index_dir: &Path, rebuild: bool) -> R
         mode: Mode::Decompose(Penalty::default()),
     };
 
+    index
+        .tokenizers()
+        .register("whitespace_tokenizer", WhitespaceTokenizer);
     index.tokenizers().register("raw_tokenizer", RawTokenizer);
     let tokenizer_name = Lang::Ja.tokenizer_name();
     let ja_tokenizer =

--- a/src/text_engine/schema.rs
+++ b/src/text_engine/schema.rs
@@ -341,10 +341,12 @@ pub fn build_schema() -> Schema {
 
     constructor.build_simple_text_fields(&[
         PostField::Body,
-        PostField::Tags,
         PostField::CreatedAtFormat,
         PostField::UpdatedAtFormat,
     ]);
+
+    constructor.build_custom_tokenizer_text_field("whitespace_tokenizer", &[PostField::Tags]);
+
     constructor.build_custom_tokenizer_text_field(
         "raw_tokenizer",
         &[


### PR DESCRIPTION
## Problem

SimpleTokenizer is indexing by punctuation like `.` or `-`, so some tags are not detected.

## Solve

Using `WhitespaceTokenizer` instead of `SimpleTokenizer` for the tag field.